### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/vplus-core/src/main/AndroidManifest.xml
+++ b/vplus-core/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <!--读取设备信息-->
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE"/>
 
     <!--应用更新插件里面已经声明了-->
     <!--安装未知来源应用的权限 https://github.com/yjfnypeu/UpdatePlugin/issues/51-->


### PR DESCRIPTION
添加读取deviceID权限，参考官方文档，Requires Permission: READ_PRIVILEGED_PHONE_STATE, for the calling app to be the device or profile owner and have the READ_PHONE_STATE permission